### PR TITLE
Add alternative approach for administrative unit identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ In order to configure it, you will need to provide the following environment var
 - `QUERY_BASE_URL`: The base url of your vendor endpoint, so if you query endpoint is `https://mandatenbeheer.lblod.info/vendor/query` your query base url will be `https://mandatenbeheer.lblod.info`.
 - `VENDOR_KEY`: The key provided by the vendor for authentication.
 - `VENDOR_URI`: The uri provided by the vendor for authentication.
-- `AUTH_GROUP`: The auth group to check for the administrative unit the user belongs to.
+
+You will also need to provide one of the following two environment variables. These are used to identify the administrative unit to authenticate with.
+- `ADMINISTRATIVE_UNIT_ID`: the id of the administrative unit to authenticate with.
+- `AUTH_GROUP`: The auth group to check for the administrative unit the user belongs to. Not used if `ADMINISTRATIVE_UNIT_ID` is defined.
 
 You will also need to add the service to your dispatcher as the service needs to get your authGroups in order to determine which administrative unit do you belong, something like this
 ```


### PR DESCRIPTION
### Overview
This PR adds an alternative approach for administrative unit identification through the `ADMINISTRATIVE_UNIT_ID` env var.
It allows the developer using this service to pass an administrative unit id directly and not use the `AUTH_GROUP` approach, which can be handy for testing.
Note: the `ADMINISTRATIVE_UNIT_ID` var always takes precedence over the `AUTH_GROUP` var.

### Setup
N/A

### How to test/reproduce
- Plug-in this service in your stack of choice
- Instead of providing the  `AUTH_GROUP` env var, provide the  `ADMINISTRATIVE_UNIT_ID` env var.
- Verify the service runs as expected and it authenticates using the value of `ADMINISTRATIVE_UNIT_ID`

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
